### PR TITLE
Some tweaks

### DIFF
--- a/src/cheque.clj
+++ b/src/cheque.clj
@@ -1,97 +1,90 @@
 (ns cheque)
 
-(def humanizedNumbers {
-  1 "um",
-  2 "dois",
-  3 "tres",
-  4 "quatro",
-  5 "cinco",
-  6 "seis",
-  7 "sete",
-  8 "oito",
-  9 "nove",
-  10 "dez",
-  11 "onze",
-  12 "doze",
-  13 "treze",
-  14 "quatorze",
-  15 "quinze",
-  16 "dezesseis",
-  17 "dezessete",
-  18 "dezoito",
-  19 "dezenove",
-  20 "vinte",
-  30 "trinta",
-  40 "quarenta",
-  50 "cinquenta",
-  60 "sessenta",
-  70 "setenta",
-  80 "oitenta",
-  90 "noventa",
-  100 "cento",
-  200 "duzentos",
-  300 "trezentos",
-  400 "quatrocentos",
-  500 "quinhentos",
-  600 "seicentos",
-  700 "setecentos",
-  800 "oitocentos",
-  900 "novecentos"})
+(def humanized-numbers
+  {1 "um",
+   2 "dois",
+   3 "tres",
+   4 "quatro",
+   5 "cinco",
+   6 "seis",
+   7 "sete",
+   8 "oito",
+   9 "nove",
+   10 "dez",
+   11 "onze",
+   12 "doze",
+   13 "treze",
+   14 "quatorze",
+   15 "quinze",
+   16 "dezesseis",
+   17 "dezessete",
+   18 "dezoito",
+   19 "dezenove",
+   20 "vinte",
+   30 "trinta",
+   40 "quarenta",
+   50 "cinquenta",
+   60 "sessenta",
+   70 "setenta",
+   80 "oitenta",
+   90 "noventa",
+   100 "cento",
+   200 "duzentos",
+   300 "trezentos",
+   400 "quatrocentos",
+   500 "quinhentos",
+   600 "seicentos",
+   700 "setecentos",
+   800 "oitocentos",
+   900 "novecentos"})
 
-(defn humanize [money])
+(declare humanize)
 
-(defn humanizeDezena [money]
+(defn humanize-dezena [money]
+  (let [mod-10 (mod money 10)]
+    (cond
+      (or (<= money 20) (zero? mod-10)) (humanized-numbers money)
+      (> money 20) (str (humanize-dezena (- money mod-10))
+                        " e "
+                        (humanize-dezena mod-10)))))
 
-  (cond
-    (or (<= money 20) (= (mod money 10) 0)) (get humanizedNumbers money)
-    (> money 20) (str (humanizeDezena (- money (mod money 10))) " e " (humanizeDezena (mod money 10)))
-    :else ""))
-
-(defn humanizeCentena [money]
+(defn humanize-centena [money]
   (cond
     (= money 100) "cem"
-    (= (mod money 100) 0) (get humanizedNumbers money)
-    :else (str (humanizeCentena (- money (mod money 100))) " e " (humanizeDezena (mod money 100)))))
+    (zero? (mod money 100)) (humanized-numbers money)
+    :else (str (humanize-centena (- money (mod money 100)))
+               " e "
+               (humanize-dezena (mod money 100)))))
 
-(defn humanizeMilhar [money]
+(defn humanize-milhar [money]
   (str
     (humanize (quot money 1000)) " mil"
-    (cond
-      (> (mod money 1000) 0) (str " e " (humanize (mod money 1000)))
-      :else "")))
+    (if (> (mod money 1000) 0)
+      (str " e " (humanize (mod money 1000))))))
 
 (defn humanize [money]
-
-  (def len (alength (to-array (str money))))
-  (cond
-    (<= len 2) (humanizeDezena money)
-    (= len 3) (humanizeCentena money)
-    (>= len 4) (humanizeMilhar money)
-    :else "" ))
-
-(defn humanizeWithCurrency [money]
-  (def reais (Math/abs (int money)))
-  (def cents (int (* 100 (- (BigDecimal. (str money)) reais))))
-
-  (def sinal (cond (< money 0) "menos " :else ""))
-
-  (def humReais
-  (cond
-    (= reais 0) ""
-    (= reais 1) (str (humanize reais) " real")
-    :else (str (humanize reais) " reais")))
-
-  (def humCents
+  (let [len (count (str money))]
     (cond
-      (= cents 0) ""
-      (= cents 1) (str (humanize cents) " centavo")
-      :else (str (humanize cents) " centavos")))
+      (<= len 2) (humanize-dezena money)
+      (= len 3) (humanize-centena money)
+      (>= len 4) (humanize-milhar money))))
 
+(defn humanize-with-currency [money]
+  (let [reais (Math/abs (int money))
+        cents (int (* 100
+                      (- (BigDecimal. (str money)) reais)))
+        sinal (if (neg? money)
+                "menos ")
+        humReais (cond
+                   (= reais 1) (str (humanize reais) " real")
+                   :else (str (humanize reais) " reais"))
+        humCents (cond
+                   (= cents 1) (str (humanize cents) " centavo")
+                   :else (str (humanize cents) " centavos"))]
   (str
     sinal
     (cond
       (and (> cents 0) (> reais 0)) (str humReais " e " humCents)
       (> reais 0) humReais
-      (> cents 0) humCents
-      :else "")))
+      (> cents 0) humCents))))
 

--- a/test/cheque_test.clj
+++ b/test/cheque_test.clj
@@ -1,71 +1,70 @@
 (ns cheque-test
-  (:use clojure.test cheque)
-  )
+  (:use clojure.test cheque))
 
 (deftest chequeDezReais
   (testing "should return dez reais when pass 10"
-    (is (= (humanizeWithCurrency 10) "dez reais"))))
+    (is (= (humanize-with-currency 10) "dez reais"))))
 
 (deftest chequeOnzeReais
   (testing "should return onze reais when pass 11"
-    (is (= (humanizeWithCurrency 11) "onze reais"))))
+    (is (= (humanize-with-currency 11) "onze reais"))))
 
 (deftest chequeVinteUmReais
   (testing "should return vinte e um reais when pass 21"
-    (is (= (humanizeWithCurrency 21) "vinte e um reais"))))
+    (is (= (humanize-with-currency 21) "vinte e um reais"))))
 
 (deftest chequeTrintaDoisReais
   (testing "should return trinta e dois reais when pass 32"
-    (is (= (humanizeWithCurrency 32) "trinta e dois reais"))))
+    (is (= (humanize-with-currency 32) "trinta e dois reais"))))
 
 (deftest chequeCinquentaReais
   (testing "should return cinquenta reais when pass 50"
-    (is (= (humanizeWithCurrency 50) "cinquenta reais"))))
+    (is (= (humanize-with-currency 50) "cinquenta reais"))))
 
 (deftest chequeTrezentosOitentaReais
   (testing "should return trezentos e oitenta reais when pass 380"
-    (is (= (humanizeWithCurrency 380) "trezentos e oitenta reais"))))
+    (is (= (humanize-with-currency 380) "trezentos e oitenta reais"))))
 
 (deftest chequeNovecentosNoventaNoveReais
   (testing "should return novecentos e noventa e nove reais when pass 999"
-    (is (= (humanizeWithCurrency 999) "novecentos e noventa e nove reais"))))
+    (is (= (humanize-with-currency 999) "novecentos e noventa e nove reais"))))
 
 (deftest chequeQuinzeMilQuatrocentosVinteReais
   (testing "should return quinze mil e quatrocentos e vinte reais when pass 15420"
-    (is (= (humanizeWithCurrency 15420) "quinze mil e quatrocentos e vinte reais"))))
+    (is (= (humanize-with-currency 15420) "quinze mil e quatrocentos e vinte reais"))))
 
 (deftest chequeVinteMilReais
   (testing "should return vinte mil reais when pass 20000"
-    (is (= (humanizeWithCurrency 20000) "vinte mil reais"))))
+    (is (= (humanize-with-currency 20000) "vinte mil reais"))))
 
 (deftest chequeCemReais
   (testing "should return cem reais when pass 100"
-    (is (= (humanizeWithCurrency 100) "cem reais"))))
+    (is (= (humanize-with-currency 100) "cem reais"))))
 
 (deftest chequeCemReaisDezCentavos
   (testing "should return cem reais e dez centavos when pass 100.10"
-    (is (= (humanizeWithCurrency 100.10) "cem reais e dez centavos"))))
+    (is (= (humanize-with-currency 100.10) "cem reais e dez centavos"))))
 
 (deftest chequeUmReal
   (testing "should return um real when pass 1"
-    (is (= (humanizeWithCurrency 1) "um real"))))
+    (is (= (humanize-with-currency 1) "um real"))))
 
 (deftest chequeMenosCemReais
   (testing "should return menos cem reais when pass -100"
-    (is (= (humanizeWithCurrency -100) "menos cem reais"))))
+    (is (= (humanize-with-currency -100) "menos cem reais"))))
 
 (deftest chequeDezReaisCincoCentavos
   (testing "should return dez reais e cinco centavos when pass 10.05"
-    (is (= (humanizeWithCurrency 10.05) "dez reais e cinco centavos"))))
+    (is (= (humanize-with-currency 10.05) "dez reais e cinco centavos"))))
 
 (deftest chequeVinteCincoCentavos
   (testing "should return vinte e cinco centavos when pass 0.25"
-    (is (= (humanizeWithCurrency 0.25) "vinte e cinco centavos"))))
+    (is (= (humanize-with-currency 0.25) "vinte e cinco centavos"))))
 
 (deftest chequeZero
   (testing "should return nothing when pass 0"
-    (is (= (humanizeWithCurrency 0) ""))))
+    (is (= (humanize-with-currency 0) ""))))
 
 (deftest chequeUmCentavo
   (testing "should return um centavo when pass 0.01"
-    (is (= (humanizeWithCurrency 0.01) "um centavo"))))
+    (is (= (humanize-with-currency 0.01) "um centavo"))))


### PR DESCRIPTION
Only introduces some idiomatic Clojure constructs to the existing
solution like:
- Use of `declare` to make forward declarations
- Use of `let` instead of inner `def`s
- Idiomatic functions like `zero?` and `neg?`
- lisp-case
- Clojure-ish way to get length of numbers with `(count (str money))`
- Returning `nil` instead of empty string, saving lines `(= (str "a" nil) "a")`
- Lisp-like indentation

I hope I covered everything.

Nothing was changed on the program logic.
